### PR TITLE
feat: add prefer_icon_widgets config with smart ASCII fallback

### DIFF
--- a/home_manager/module.nix
+++ b/home_manager/module.nix
@@ -196,7 +196,13 @@ in {
       default = "yazelix";
       description = "Session name for persistent sessions";
     };
-    
+
+    prefer_icon_widgets = mkOption {
+      type = types.bool;
+      default = true;
+      description = "Prefer Nerd Font icons in zjstatus bar (automatically falls back to ASCII for external terminals)";
+    };
+
     language_packs = mkOption {
       type = types.listOf (types.enum [ "python" "ts" "rust" "go" "kotlin" "gleam" "nix" ]);
       default = [];
@@ -290,6 +296,7 @@ in {
           "rounded_corners = ${boolToToml cfg.zellij_rounded_corners}"
           "persistent_sessions = ${boolToToml cfg.persistent_sessions}"
           "session_name = ${escapeString cfg.session_name}"
+          "prefer_icon_widgets = ${boolToToml cfg.prefer_icon_widgets}"
           ""
           "[ascii]"
           "mode = ${escapeString cfg.ascii_art_mode}"

--- a/nushell/scripts/setup/zellij_config_merger.nu
+++ b/nushell/scripts/setup/zellij_config_merger.nu
@@ -200,19 +200,16 @@ export def generate_merged_zellij_config [yazelix_dir: string] {
     # Ensure output directory exists
     ensure_dir $merged_config_path
     
-    # Copy layouts directory to merged config location
+    # Generate layouts directory with icon or ASCII widgets based on config and terminal
     let source_layouts_dir = $"($yazelix_dir)/($ZELLIJ_CONFIG_PATHS.layouts_dir)"
     let target_layouts_dir = $"($merged_config_dir)/layouts"
     if ($source_layouts_dir | path exists) {
-        if not ($target_layouts_dir | path exists) {
-            mkdir $target_layouts_dir
-        }
-        # Copy all layout files
-        let layout_files = (ls $source_layouts_dir | where type == file | get name)
-        for file in $layout_files {
-            let filename = ($file | path basename)
-            cp $file $"($target_layouts_dir)/($filename)"
-        }
+        # Determine if we should use icons based on config and terminal capability
+        let use_icons = (nu ~/.config/yazelix/nushell/scripts/utils/icon_widget_detector.nu | $in == "icons")
+
+        # Generate layouts with appropriate widget style
+        use ../utils/layout_generator.nu
+        layout_generator generate_all_layouts $source_layouts_dir $target_layouts_dir $use_icons
     }
     
     # Generate merged configuration

--- a/nushell/scripts/utils/icon_widget_detector.nu
+++ b/nushell/scripts/utils/icon_widget_detector.nu
@@ -1,0 +1,44 @@
+#!/usr/bin/env nu
+# Determine whether to use icon widgets in zjstatus based on config and terminal capability
+
+use config_parser.nu parse_yazelix_config
+use constants.nu *
+
+# Check if the terminal was launched by Yazelix (not an external terminal)
+# This is the only reliable way to know if Nerd Fonts are configured
+export def is_yazelix_launched_terminal []: nothing -> bool {
+    # YAZELIX_TERMINAL is set when launching via "yzx launch" or launch_yazelix.nu
+    # If this env var is present, we know it's a Yazelix-managed launch with Nerd Fonts
+    # If absent, it's either "yzx launch --here" or a manual external terminal launch
+    ($env.YAZELIX_TERMINAL? | is-not-empty)
+}
+
+# Determine if icon widgets should be used based on config and terminal
+export def should_use_icons []: nothing -> bool {
+    # Parse the config
+    let config = (parse_yazelix_config)
+
+    # Get user preference (defaults to true if not set)
+    let prefer_icons = ($config.zellij?.prefer_icon_widgets? | default true)
+
+    # Check if terminal was launched by Yazelix
+    let yazelix_launched = (is_yazelix_launched_terminal)
+
+    # If using external terminal (not launched by Yazelix), always use ASCII regardless of preference
+    # This covers both "yzx launch --here" and manual external terminal launches
+    if (not $yazelix_launched) {
+        return false
+    }
+
+    # If launched by Yazelix, we know Nerd Fonts are available, so respect user preference
+    return $prefer_icons
+}
+
+# Main entry point - print "icons" or "ascii"
+def main []: nothing -> string {
+    if (should_use_icons) {
+        "icons"
+    } else {
+        "ascii"
+    }
+}

--- a/nushell/scripts/utils/layout_generator.nu
+++ b/nushell/scripts/utils/layout_generator.nu
@@ -1,0 +1,74 @@
+#!/usr/bin/env nu
+# Generate Zellij layouts with icon or ASCII widgets
+
+use constants.nu *
+
+# Icon format strings (Nerd Fonts)
+const ICON_CPU_FORMAT = '#[fg=#ff6600]󰚂{stdout}'
+const ICON_RAM_FORMAT = '#[fg=#ff6600]󰇾{stdout}'
+const ICON_FLOATING = '⬚ '
+
+# ASCII format strings (universal compatibility)
+const ASCII_CPU_FORMAT = '#[fg=#ff6600][CPU {stdout}]'
+const ASCII_RAM_FORMAT = '#[fg=#ff6600][RAM {stdout}]'
+const ASCII_FLOATING = '[F] '
+
+# Generate a layout file with icon or ASCII widgets
+# Parameters:
+#   source_layout: path to the template layout file
+#   target_layout: path to the output layout file
+#   use_icons: whether to use icon widgets (true) or ASCII (false)
+export def generate_layout [
+    source_layout: string
+    target_layout: string
+    use_icons: bool
+]: nothing -> nothing {
+    # If using icons, just copy the source file directly (source has icons)
+    if $use_icons {
+        cp $source_layout $target_layout
+        return
+    }
+
+    # Otherwise, generate ASCII variant by replacing icon strings
+    let content = (open $source_layout)
+
+    # Replace icon format strings with ASCII variants
+    let updated_content = ($content
+        | str replace --all $ICON_CPU_FORMAT $ASCII_CPU_FORMAT
+        | str replace --all $ICON_RAM_FORMAT $ASCII_RAM_FORMAT
+        | str replace --all $ICON_FLOATING $ASCII_FLOATING
+    )
+
+    # Write the generated layout
+    $updated_content | save --force $target_layout
+}
+
+# Generate all layout files based on icon preference
+export def generate_all_layouts [
+    layouts_source_dir: string
+    layouts_target_dir: string
+    use_icons: bool
+]: nothing -> nothing {
+    # Ensure target directory exists
+    mkdir $layouts_target_dir
+
+    # List of layout files to process
+    let layout_files = [
+        "yzx_side.kdl"
+        "yzx_no_side.kdl"
+        "yzx_side.swap.kdl"
+        "yzx_no_side.swap.kdl"
+        "yzx_sweep_test.kdl"
+    ]
+
+    # Generate each layout file
+    for file in $layout_files {
+        let source = ($layouts_source_dir | path join $file)
+        let target = ($layouts_target_dir | path join $file)
+
+        if ($source | path exists) {
+            generate_layout $source $target $use_icons
+            print $"Generated layout: ($target) \(icons: ($use_icons)\)"
+        }
+    }
+}

--- a/yazelix_default.toml
+++ b/yazelix_default.toml
@@ -142,6 +142,12 @@ persistent_sessions = false
 # This name will be used when creating or attaching to persistent sessions
 session_name = "yazelix"
 
+# Prefer icon widgets in status bar (default: true)
+# When true, uses Nerd Font icons (󰚂 CPU, 󰇾 RAM) in the zjstatus bar
+# When false, uses ASCII fallbacks ([CPU x%], [RAM y%])
+# Note: Automatically falls back to ASCII when using external terminals without Nerd Fonts
+prefer_icon_widgets = true
+
 [ascii]
 # Options:
 # - "static":   Show static ASCII art


### PR DESCRIPTION
Adds configurable icon widgets in zjstatus bar with automatic ASCII fallback for external terminals without Nerd Font support.

Changes:
- Add prefer_icon_widgets config option (default: true) to yazelix_default.toml
- Sync option to Home Manager module
- Create icon_widget_detector.nu to determine icon vs ASCII based on:
  - User's prefer_icon_widgets setting
  - Whether terminal was launched by Yazelix (YAZELIX_TERMINAL env var)
- Create layout_generator.nu to dynamically generate layouts with:
  - Icon widgets: 󰚂 CPU, 󰇾 RAM, ⬚ Floating
  - ASCII fallback: [CPU x%], [RAM y%], [F] Floating
- Update zellij_config_merger.nu to generate layouts dynamically

Behavior:
- Yazelix-launched terminals: Use icons (default) or ASCII (if prefer_icon_widgets=false)
- External terminals (yzx launch --here): Always use ASCII fallback
- Ensures compatibility with non-Yazelix-configured terminals