### PR TITLE
Add vertical_split and horizontal_split cursor families

### DIFF
--- a/configs/terminal_emulators/ghostty/shaders/README.md
+++ b/configs/terminal_emulators/ghostty/shaders/README.md
@@ -21,7 +21,9 @@ shaders/
 │   ├── dusk.glsl
 │   ├── orchid.glsl
 │   ├── reef.glsl
-│   └── inferno.glsl
+│   ├── inferno.glsl
+│   ├── ember.glsl
+│   └── horizon.glsl
 ├── build_shaders.nu             # Build script (nushell, runs automatically)
 └── cursor_trail_*.glsl          # Generated locally/runtime only (gitignored)
 ```
@@ -113,3 +115,11 @@ The build is **fully automatic**:
 ### Vertical Gradient (1 variant)
 - `inferno`
 - Vertical directional blending
+
+### Vertical Split (1 variant)
+- `ember`
+- Split trail into top/bottom halves with distinct colors
+
+### Horizontal Split (1 variant)
+- `horizon`
+- Split trail into left/right halves with distinct colors

--- a/configs/terminal_emulators/ghostty/shaders/cursor_trail_common.glsl
+++ b/configs/terminal_emulators/ghostty/shaders/cursor_trail_common.glsl
@@ -206,6 +206,112 @@ void renderOrbitDualColorTrail(
     fragColor = mix(trail, fragColor, 1. - smoothstep(0., sdfCurrentCursor, easedProgress * lineLength));
 }
 
+void renderVerticalSplitTrail(
+    out vec4 fragColor,
+    in vec2 fragCoord,
+    vec4 color0,
+    vec4 color1,
+    float duration,
+    float pulseFrequency
+) {
+    #if !defined(WEB)
+    fragColor = texture(iChannel0, fragCoord.xy / iResolution.xy);
+    #endif
+    vec2 vu = normalize(fragCoord, 1.);
+    vec2 offsetFactor = vec2(-.5, 0.5);
+
+    vec4 currentCursor = vec4(normalize(iCurrentCursor.xy, 1.), normalize(iCurrentCursor.zw, 0.));
+    vec4 previousCursor = vec4(normalize(iPreviousCursor.xy, 1.), normalize(iPreviousCursor.zw, 0.));
+
+    vec2 centerCC = getRectangleCenter(currentCursor);
+    vec2 centerCP = getRectangleCenter(previousCursor);
+    float vertexFactor = determineStartVertexFactor(currentCursor.xy, previousCursor.xy);
+    float invertedVertexFactor = 1.0 - vertexFactor;
+
+    vec2 v0 = vec2(currentCursor.x + currentCursor.z * vertexFactor, currentCursor.y - currentCursor.w);
+    vec2 v1 = vec2(currentCursor.x + currentCursor.z * invertedVertexFactor, currentCursor.y);
+    vec2 v2 = vec2(previousCursor.x + currentCursor.z * invertedVertexFactor, previousCursor.y);
+    vec2 v3 = vec2(previousCursor.x + currentCursor.z * vertexFactor, previousCursor.y - previousCursor.w);
+
+    float sdfCurrentCursor = getSdfRectangle(vu, currentCursor.xy - (currentCursor.zw * offsetFactor), currentCursor.zw * 0.5);
+    float sdfTrail = getSdfParallelogram(vu, v0, v1, v2, v3);
+
+    float progress = clamp((iTime - iTimeCursorChange) / duration, 0.0, 1.0);
+    float easedProgress = ease(progress);
+    float lineLength = distance(centerCC, centerCP);
+
+    float mod = .005;
+    vec2 dir = normalize(vu - centerCC + 1e-6);
+    float verticalMix = smoothstep(-0.08, 0.08, dir.y);
+    float pulse = 0.05 * sin(iTime * pulseFrequency);
+    float edgeMix = clamp(verticalMix + pulse * 0.5, 0.0, 1.0);
+
+    vec4 base = mix(color0, color1, verticalMix);
+    vec4 edge = mix(color0, color1, edgeMix);
+
+    vec4 trail = fragColor;
+    trail = applyTrailLayer(trail, saturate(base, 1.6), trailGlowMask(sdfTrail, mod + 0.010, 0.035));
+    trail = applyTrailLayer(trail, saturate(edge, 1.7), trailEdgeMask(sdfTrail, mod, 0.006));
+    trail = mix(trail, saturate(base, 1.65), trailCoreMask(sdfTrail, mod));
+
+    trail = applyTrailLayer(trail, saturate(edge, 1.7), cursorGlowMask(sdfCurrentCursor, .002, 0.004));
+    trail = applyTrailLayer(trail, saturate(base, 1.65), cursorEdgeMask(sdfCurrentCursor, .002, 0.004));
+    fragColor = mix(trail, fragColor, 1. - smoothstep(0., sdfCurrentCursor, easedProgress * lineLength));
+}
+
+void renderHorizontalSplitTrail(
+    out vec4 fragColor,
+    in vec2 fragCoord,
+    vec4 color0,
+    vec4 color1,
+    float duration,
+    float pulseFrequency
+) {
+    #if !defined(WEB)
+    fragColor = texture(iChannel0, fragCoord.xy / iResolution.xy);
+    #endif
+    vec2 vu = normalize(fragCoord, 1.);
+    vec2 offsetFactor = vec2(-.5, 0.5);
+
+    vec4 currentCursor = vec4(normalize(iCurrentCursor.xy, 1.), normalize(iCurrentCursor.zw, 0.));
+    vec4 previousCursor = vec4(normalize(iPreviousCursor.xy, 1.), normalize(iPreviousCursor.zw, 0.));
+
+    vec2 centerCC = getRectangleCenter(currentCursor);
+    vec2 centerCP = getRectangleCenter(previousCursor);
+    float vertexFactor = determineStartVertexFactor(currentCursor.xy, previousCursor.xy);
+    float invertedVertexFactor = 1.0 - vertexFactor;
+
+    vec2 v0 = vec2(currentCursor.x + currentCursor.z * vertexFactor, currentCursor.y - currentCursor.w);
+    vec2 v1 = vec2(currentCursor.x + currentCursor.z * invertedVertexFactor, currentCursor.y);
+    vec2 v2 = vec2(previousCursor.x + currentCursor.z * invertedVertexFactor, previousCursor.y);
+    vec2 v3 = vec2(previousCursor.x + currentCursor.z * vertexFactor, previousCursor.y - previousCursor.w);
+
+    float sdfCurrentCursor = getSdfRectangle(vu, currentCursor.xy - (currentCursor.zw * offsetFactor), currentCursor.zw * 0.5);
+    float sdfTrail = getSdfParallelogram(vu, v0, v1, v2, v3);
+
+    float progress = clamp((iTime - iTimeCursorChange) / duration, 0.0, 1.0);
+    float easedProgress = ease(progress);
+    float lineLength = distance(centerCC, centerCP);
+
+    float mod = .005;
+    vec2 dir = normalize(vu - centerCC + 1e-6);
+    float horizontalMix = smoothstep(-0.08, 0.08, dir.x);
+    float pulse = 0.05 * sin(iTime * pulseFrequency);
+    float edgeMix = clamp(horizontalMix + pulse * 0.5, 0.0, 1.0);
+
+    vec4 base = mix(color0, color1, horizontalMix);
+    vec4 edge = mix(color0, color1, edgeMix);
+
+    vec4 trail = fragColor;
+    trail = applyTrailLayer(trail, saturate(base, 1.6), trailGlowMask(sdfTrail, mod + 0.010, 0.035));
+    trail = applyTrailLayer(trail, saturate(edge, 1.7), trailEdgeMask(sdfTrail, mod, 0.006));
+    trail = mix(trail, saturate(base, 1.65), trailCoreMask(sdfTrail, mod));
+
+    trail = applyTrailLayer(trail, saturate(edge, 1.7), cursorGlowMask(sdfCurrentCursor, .002, 0.004));
+    trail = applyTrailLayer(trail, saturate(base, 1.65), cursorEdgeMask(sdfCurrentCursor, .002, 0.004));
+    fragColor = mix(trail, fragColor, 1. - smoothstep(0., sdfCurrentCursor, easedProgress * lineLength));
+}
+
 void renderAxisGradientTrail(
     out vec4 fragColor,
     in vec2 fragCoord,

--- a/configs/terminal_emulators/ghostty/shaders/variants/ember.glsl
+++ b/configs/terminal_emulators/ghostty/shaders/variants/ember.glsl
@@ -1,0 +1,10 @@
+// Ember variant: vertical split (flame orange ↑, deep navy ↓)
+
+const vec4 EMBER_FLAME = vec4(1.0, 0.271, 0.0, 1.0);   // #FF4500
+const vec4 EMBER_NAVY = vec4(0.102, 0.102, 0.180, 1.0);  // #1A1A2E
+const float DURATION = 0.24;
+
+void mainImage(out vec4 fragColor, in vec2 fragCoord)
+{
+    renderVerticalSplitTrail(fragColor, fragCoord, EMBER_FLAME, EMBER_NAVY, DURATION, 1.8);
+}

--- a/configs/terminal_emulators/ghostty/shaders/variants/horizon.glsl
+++ b/configs/terminal_emulators/ghostty/shaders/variants/horizon.glsl
@@ -1,0 +1,10 @@
+// Horizon variant: horizontal split (midnight blue ←, rose red →)
+
+const vec4 HORIZON_MIDNIGHT = vec4(0.059, 0.204, 0.376, 1.0); // #0F3460
+const vec4 HORIZON_ROSE = vec4(0.914, 0.271, 0.376, 1.0);     // #E94560
+const float DURATION = 0.24;
+
+void mainImage(out vec4 fragColor, in vec2 fragCoord)
+{
+    renderHorizontalSplitTrail(fragColor, fragCoord, HORIZON_MIDNIGHT, HORIZON_ROSE, DURATION, 1.6);
+}

--- a/rust_core/yazelix_core/src/ghostty_cursor_registry.rs
+++ b/rust_core/yazelix_core/src/ghostty_cursor_registry.rs
@@ -54,6 +54,8 @@ pub struct CursorDefinition {
 pub enum CursorFamily {
     SimpleDual,
     AxisGradient,
+    VerticalSplit,
+    HorizontalSplit,
     CuratedTemplate,
 }
 
@@ -270,7 +272,7 @@ impl CursorDefinition {
                 "./shaders/cursor_trail_{}.glsl",
                 self.template.as_deref().unwrap_or(&self.name)
             ),
-            CursorFamily::SimpleDual | CursorFamily::AxisGradient => {
+            CursorFamily::SimpleDual | CursorFamily::AxisGradient | CursorFamily::VerticalSplit | CursorFamily::HorizontalSplit => {
                 format!("./shaders/cursor_trail_{}.glsl", self.name)
             }
         }
@@ -373,13 +375,15 @@ fn validate_definition(
     let family = match raw.family.trim() {
         "simple_dual" => CursorFamily::SimpleDual,
         "axis_gradient" => CursorFamily::AxisGradient,
+        "vertical_split" => CursorFamily::VerticalSplit,
+        "horizontal_split" => CursorFamily::HorizontalSplit,
         "curated_template" => CursorFamily::CuratedTemplate,
         other => {
             return Err(invalid_cursor_config(
                 path,
                 "cursor.family",
                 format!(
-                    "Cursor '{name}' uses unsupported family '{other}'. Expected simple_dual, axis_gradient, or curated_template."
+                    "Cursor '{name}' uses unsupported family '{other}'. Expected simple_dual, axis_gradient, vertical_split, horizontal_split, or curated_template."
                 ),
             ));
         }
@@ -391,7 +395,7 @@ fn validate_definition(
     )?;
 
     match family {
-        CursorFamily::SimpleDual | CursorFamily::AxisGradient => {
+        CursorFamily::SimpleDual | CursorFamily::AxisGradient | CursorFamily::VerticalSplit | CursorFamily::HorizontalSplit => {
             if raw.colors.len() != 2 {
                 return Err(invalid_cursor_config(
                     path,
@@ -686,6 +690,8 @@ cursor_color = "#ffffff"
 
         assert!(registry.enabled_cursors.contains(&"blaze".to_string()));
         assert!(registry.enabled_cursors.contains(&"neon".to_string()));
+        assert!(registry.enabled_cursors.contains(&"ember".to_string()));
+        assert!(registry.enabled_cursors.contains(&"horizon".to_string()));
         assert!(
             registry
                 .enabled_cursors
@@ -693,5 +699,119 @@ cursor_color = "#ffffff"
                 .all(|name| registry.definitions.contains_key(name))
         );
         assert_eq!(registry.settings.trail, "random");
+    }
+
+    // Defends: vertical_split family with exactly 2 colors parses as a valid data-driven cursor definition.
+    // Strength: defect=2 behavior=2 resilience=1 cost=1 uniqueness=2 total=8/10
+    #[test]
+    fn registry_parses_vertical_split_with_two_colors() {
+        let raw = base_registry(
+            r##"
+[[cursor]]
+name = "ember"
+family = "vertical_split"
+colors = ["#ff4500", "#1a1a2e"]
+cursor_color = "#ff4500"
+"##,
+        )
+        .replace(
+            "enabled_cursors = [\"blaze\"]",
+            "enabled_cursors = [\"blaze\", \"ember\"]",
+        );
+        let (_temp, path) = write_registry(&raw);
+
+        let registry = CursorRegistry::load(&path).unwrap();
+
+        let def = registry.definitions.get("ember").unwrap();
+        assert_eq!(def.family, CursorFamily::VerticalSplit);
+        assert_eq!(def.colors.len(), 2);
+        assert_eq!(def.shader_path(), "./shaders/cursor_trail_ember.glsl");
+    }
+
+    // Defends: horizontal_split family with exactly 2 colors parses as a valid data-driven cursor definition.
+    // Strength: defect=2 behavior=2 resilience=1 cost=1 uniqueness=2 total=8/10
+    #[test]
+    fn registry_parses_horizontal_split_with_two_colors() {
+        let raw = base_registry(
+            r##"
+[[cursor]]
+name = "horizon"
+family = "horizontal_split"
+colors = ["#0f3460", "#e94560"]
+cursor_color = "#e94560"
+"##,
+        )
+        .replace(
+            "enabled_cursors = [\"blaze\"]",
+            "enabled_cursors = [\"blaze\", \"horizon\"]",
+        );
+        let (_temp, path) = write_registry(&raw);
+
+        let registry = CursorRegistry::load(&path).unwrap();
+
+        let def = registry.definitions.get("horizon").unwrap();
+        assert_eq!(def.family, CursorFamily::HorizontalSplit);
+        assert_eq!(def.colors.len(), 2);
+        assert_eq!(def.shader_path(), "./shaders/cursor_trail_horizon.glsl");
+    }
+
+    // Defends: vertical_split rejects color counts other than 2, preventing malformed shader generation.
+    // Strength: defect=2 behavior=2 resilience=2 cost=1 uniqueness=2 total=9/10
+    #[test]
+    fn registry_rejects_vertical_split_with_wrong_color_count() {
+        for (label, colors) in [
+            ("too_few", "[\"#ff4500\"]"),
+            ("too_many", "[\"#ff4500\", \"#1a1a2e\", \"#ffffff\"]"),
+        ] {
+            let raw = base_registry(&format!(
+                r##"
+[[cursor]]
+name = "bad_vs_{label}"
+family = "vertical_split"
+colors = {colors}
+cursor_color = "#ff4500"
+"##
+            ))
+            .replace(
+                "enabled_cursors = [\"blaze\"]",
+                &format!("enabled_cursors = [\"blaze\", \"bad_vs_{label}\"]"),
+            );
+            let (_temp, path) = write_registry(&raw);
+
+            let error = CursorRegistry::load(&path).unwrap_err();
+
+            assert_eq!(error.code(), "invalid_cursor_config");
+            assert!(format!("{error:?}").contains("requires exactly 2 colors"));
+        }
+    }
+
+    // Defends: horizontal_split rejects color counts other than 2, preventing malformed shader generation.
+    // Strength: defect=2 behavior=2 resilience=2 cost=1 uniqueness=2 total=9/10
+    #[test]
+    fn registry_rejects_horizontal_split_with_wrong_color_count() {
+        for (label, colors) in [
+            ("too_few", "[\"#0f3460\"]"),
+            ("too_many", "[\"#0f3460\", \"#e94560\", \"#ffffff\"]"),
+        ] {
+            let raw = base_registry(&format!(
+                r##"
+[[cursor]]
+name = "bad_hs_{label}"
+family = "horizontal_split"
+colors = {colors}
+cursor_color = "#e94560"
+"##
+            ))
+            .replace(
+                "enabled_cursors = [\"blaze\"]",
+                &format!("enabled_cursors = [\"blaze\", \"bad_hs_{label}\"]"),
+            );
+            let (_temp, path) = write_registry(&raw);
+
+            let error = CursorRegistry::load(&path).unwrap_err();
+
+            assert_eq!(error.code(), "invalid_cursor_config");
+            assert!(format!("{error:?}").contains("requires exactly 2 colors"));
+        }
     }
 }

--- a/rust_core/yazelix_core/src/ghostty_materialization.rs
+++ b/rust_core/yazelix_core/src/ghostty_materialization.rs
@@ -370,7 +370,10 @@ fn write_data_driven_cursor_shaders(
         .filter(|definition| {
             matches!(
                 definition.family,
-                CursorFamily::SimpleDual | CursorFamily::AxisGradient
+                CursorFamily::SimpleDual
+                    | CursorFamily::AxisGradient
+                    | CursorFamily::VerticalSplit
+                    | CursorFamily::HorizontalSplit
             )
         })
         .collect::<Vec<_>>();
@@ -444,6 +447,38 @@ const float DURATION = {duration};
 void mainImage(out vec4 fragColor, in vec2 fragCoord)
 {{
     renderAxisGradientTrail(fragColor, fragCoord, YAZELIX_CURSOR_COLOR_0, YAZELIX_CURSOR_COLOR_1, DURATION, 1.6, 0.42, 0.30, 0.5);
+}}
+"#
+            )
+        }
+        CursorFamily::VerticalSplit => {
+            let duration = format_ghostty_trail_duration(0.24 * duration_scale);
+            format!(
+                r#"// Generated Yazelix vertical-split cursor variant
+
+const vec4 YAZELIX_CURSOR_COLOR_0 = {color_0};
+const vec4 YAZELIX_CURSOR_COLOR_1 = {color_1};
+const float DURATION = {duration};
+
+void mainImage(out vec4 fragColor, in vec2 fragCoord)
+{{
+    renderVerticalSplitTrail(fragColor, fragCoord, YAZELIX_CURSOR_COLOR_0, YAZELIX_CURSOR_COLOR_1, DURATION, 1.8);
+}}
+"#
+            )
+        }
+        CursorFamily::HorizontalSplit => {
+            let duration = format_ghostty_trail_duration(0.24 * duration_scale);
+            format!(
+                r#"// Generated Yazelix horizontal-split cursor variant
+
+const vec4 YAZELIX_CURSOR_COLOR_0 = {color_0};
+const vec4 YAZELIX_CURSOR_COLOR_1 = {color_1};
+const float DURATION = {duration};
+
+void mainImage(out vec4 fragColor, in vec2 fragCoord)
+{{
+    renderHorizontalSplitTrail(fragColor, fragCoord, YAZELIX_CURSOR_COLOR_0, YAZELIX_CURSOR_COLOR_1, DURATION, 1.6);
 }}
 "#
             )

--- a/yazelix_cursors_default.toml
+++ b/yazelix_cursors_default.toml
@@ -26,6 +26,8 @@ enabled_cursors = [
   "orchid",
   "reef",
   "inferno",
+  "ember",
+  "horizon",
   # "local_lime",
 ]
 
@@ -164,6 +166,24 @@ colors = [
   "#2a3340",
 ]
 cursor_color = "#ff1600"
+
+[[cursor]]
+name = "ember"
+family = "vertical_split"
+colors = [
+  "#ff4500",
+  "#1a1a2e",
+]
+cursor_color = "#ff4500"
+
+[[cursor]]
+name = "horizon"
+family = "horizontal_split"
+colors = [
+  "#0f3460",
+  "#e94560",
+]
+cursor_color = "#e94560"
 
 # Example custom cursor
 # Uncomment the block to enable it


### PR DESCRIPTION
## Summary

Closes #572

Adds two new data-driven cursor shader families that split the cursor trail into two colored halves along a chosen axis:

- **vertical_split**: top half uses color0, bottom half uses color1, blended with smoothstep around the horizontal center line
- **horizontal_split**: left half uses color0, right half uses color1, blended with smoothstep around the vertical center line

Both families include a subtle pulse animation on the split boundary controlled by a `pulseFrequency` parameter, and follow the existing SDF trail + glow + edge + core + cursor layer structure.

## Changes

### GLSL (`cursor_trail_common.glsl`)
- `renderVerticalSplitTrail(fragColor, fragCoord, color0, color1, duration, pulseFrequency)` — uses `dir.y` smoothstep for vertical split
- `renderHorizontalSplitTrail(fragColor, fragCoord, color0, color1, duration, pulseFrequency)` — uses `dir.x` smoothstep for horizontal split

### Rust registry (`ghostty_cursor_registry.rs`)
- Add `VerticalSplit` and `HorizontalSplit` to `CursorFamily` enum
- Family parsing, validation (exactly 2 colors, no template), shader path resolution
- 4 new tests: parse-valid for each family, reject-wrong-color-count for each family
- Updated shipped-default test to assert new cursors exist

### Rust materialization (`ghostty_materialization.rs`)
- Code generation for both families calling their respective GLSL render functions
- Both families added to the data-driven shader filter

### Cursor config (`yazelix_cursors_default.toml`)
- **ember** cursor: vertical_split, #FF4500 / #1A1A2E, cursor #FF4500
- **horizon** cursor: horizontal_split, #0F3460 / #E94560, cursor #E94560
- Both added to `enabled_cursors`

### Shader variants
- `ember.glsl` — calls `renderVerticalSplitTrail`
- `horizon.glsl` — calls `renderHorizontalSplitTrail`

### Docs (`shaders/README.md`)
- Vertical Split and Horizontal Split variant category sections
- Updated directory tree listing

## Design decisions

- Inferno is NOT refactored to use the new `vertical_split` family in this PR — changing visual output of existing cursors is breaking for users. Inferno migration can be a follow-up.
- Both new families require exactly 2 colors (same as `simple_dual` / `axis_gradient`), no template field.
- Default pulse frequency: 1.8 for vertical_split, 1.6 for horizontal_split.

## Testing

- All 10 cursor registry Rust tests pass (6 existing + 4 new)
- Visual verification in Ghostty: both shaders render two distinct colors split along the expected axis with pulse animation