### PR TITLE
Fix zellij KGP cargo vendor hash

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -181,8 +181,15 @@
           };
         in
         pkgs.extend (final: prev: {
-          zellij = prev.zellij.overrideAttrs (_old: {
+          zellij = prev.zellij.overrideAttrs (old: {
+            version = "0.44.3";
             src = yazelixZellij;
+            cargoDeps = final.rustPlatform.fetchCargoVendor {
+              pname = old.pname;
+              version = "0.44.3";
+              src = yazelixZellij;
+              hash = "sha256-966FpfSsF9I10SrYe3+YNsfM2kLLv+gd0/Aw8vLp4Lk=";
+            };
           });
           yazi-unwrapped = prev.yazi-unwrapped.overrideAttrs (old: {
             srcs = [


### PR DESCRIPTION
While testing the new agent sidebar from current `main` on my own NixOS machine, after Lucca invited me to try it in #587, my system rebuild failed before I could get to the actual UX testing.

The failure was in the Yazelix KGP zellij override:

```text
ERROR: cargoHash or cargoSha256 is out of date
Cargo.lock is not the same in /build/zellij-0.44.1-vendor
```

It looks like the override was already switching `src` to `yazelixZellij`, but it was still reusing the nixpkgs `zellij` package metadata/vendor hash for `0.44.1`. The KGP source currently has a different `Cargo.lock` / dependency graph, so Nix rejects the old vendored dependency tree.

This PR updates the override to match the KGP zellij source I hit while testing:

- set the overridden zellij version to `0.44.3`
- regenerate the cargo vendor hash for `yazelixZellij`

I verified the fix locally in two ways:

- built an equivalent local zellij override successfully with the new vendor hash
- evaluated my NixOS `homePC` configuration with this patched Yazelix flake:
  `nix eval --override-input yazelix path:/tmp/yazelix-pr .#nixosConfigurations.homePC.config.system.build.toplevel.drvPath`

After this, my NixOS config gets past the zellij vendor mismatch again, so I can continue testing the actual agent sidebar workflow from #587.
