### PR TITLE
Fix doctor graphics check for host-sourced Yazi

### DIFF
--- a/rust_core/yazelix_core/src/doctor_runtime_report.rs
+++ b/rust_core/yazelix_core/src/doctor_runtime_report.rs
@@ -119,6 +119,7 @@ pub fn evaluate_doctor_runtime_report(
         shared_runtime_preflight.extend(build_runtime_graphics_findings(
             shared,
             &request.runtime_dir,
+            &runtime_tool_command_search_paths,
         ));
     }
     shared_runtime_preflight.extend(build_runtime_tool_source_findings(
@@ -178,6 +179,14 @@ fn read_runtime_tool_manifest(
     })
 }
 
+fn runtime_tool_required_commands(tool: &RuntimeToolManifestEntry) -> &[String] {
+    if tool.required_commands.is_empty() {
+        &tool.commands
+    } else {
+        &tool.required_commands
+    }
+}
+
 fn format_path_list(command_search_paths: &[PathBuf]) -> String {
     if command_search_paths.is_empty() {
         return "No command search paths were available.".into();
@@ -216,11 +225,7 @@ fn build_host_runtime_tool_findings(
         .into_iter()
         .filter(|(_, tool)| tool.source == "host")
         .map(|(name, tool)| {
-            let required_commands = if tool.required_commands.is_empty() {
-                tool.commands
-            } else {
-                tool.required_commands
-            };
+            let required_commands = runtime_tool_required_commands(&tool);
             let missing_commands = required_commands
                 .iter()
                 .filter(|command| !command_exists_in_paths(command, command_search_paths))
@@ -525,9 +530,10 @@ fn build_shared_preflight_findings(
 fn build_runtime_graphics_findings(
     shared: &SharedRuntimePreflightInput,
     runtime_dir: &Path,
+    command_search_paths: &[PathBuf],
 ) -> Vec<DoctorRuntimeDoctorFinding> {
     vec![
-        build_graphics_preview_strategy_finding(shared, runtime_dir),
+        build_graphics_preview_strategy_finding(shared, runtime_dir, command_search_paths),
         build_chafa_probe_safety_finding(runtime_dir),
     ]
 }
@@ -558,14 +564,41 @@ fn terminal_uses_yazelix_kitty_bridge(terminal: &str) -> bool {
     matches!(terminal, "ghostty" | "ratty")
 }
 
+fn host_runtime_yazi_available(runtime_dir: &Path, command_search_paths: &[PathBuf]) -> bool {
+    let manifest = match read_runtime_tool_manifest(runtime_dir) {
+        Ok(Some(manifest)) => manifest,
+        Ok(None) | Err(_) => return false,
+    };
+    let Some(tool) = manifest.get("yazi") else {
+        return false;
+    };
+    if tool.source != "host" {
+        return false;
+    }
+
+    let required_commands = runtime_tool_required_commands(tool);
+    !required_commands.is_empty()
+        && required_commands
+            .iter()
+            .all(|command| command_exists_in_paths(command, command_search_paths))
+}
+
 fn build_graphics_preview_strategy_finding(
     shared: &SharedRuntimePreflightInput,
     runtime_dir: &Path,
+    command_search_paths: &[PathBuf],
 ) -> DoctorRuntimeDoctorFinding {
     let terminal = first_configured_terminal(&shared.terminals);
     let bridge_marker = runtime_feature_enabled(runtime_dir, ZELLIJ_KITTY_PASSTHROUGH_FEATURE);
     let zellij_present = runtime_command_present(runtime_dir, "zellij");
     let yazi_present = runtime_command_present(runtime_dir, "yazi");
+    let host_yazi_present = host_runtime_yazi_available(runtime_dir, command_search_paths);
+    let yazi_runtime_or_host_present = yazi_present || host_yazi_present;
+    let yazi_owner = if yazi_present {
+        "runtime-owned"
+    } else {
+        "host-sourced"
+    };
     let details = vec![
         format!("First configured terminal: {terminal}"),
         format!(
@@ -582,18 +615,24 @@ fn build_graphics_preview_strategy_finding(
         ),
         format!(
             "Runtime Yazi command: {}",
-            if yazi_present { "present" } else { "missing" }
+            if yazi_present {
+                "present"
+            } else if host_yazi_present {
+                "host PATH"
+            } else {
+                "missing"
+            }
         ),
         "Chafa probing is reported separately and is not treated as proof of high-quality image-preview support.".into(),
     ];
 
     if terminal_uses_yazelix_kitty_bridge(&terminal) {
-        if bridge_marker && zellij_present && yazi_present {
+        if bridge_marker && zellij_present && yazi_runtime_or_host_present {
             return DoctorRuntimeDoctorFinding {
                 status: "ok".into(),
                 message: "Graphics previews: Yazelix Kitty passthrough bridge is active".into(),
                 details: Some(format!(
-                    "{}\nPreview strategy: Yazi image previews use Kitty graphics through the packaged Zellij/Yazi bridge.",
+                    "{}\nPreview strategy: Yazi image previews use Kitty graphics through the packaged Zellij bridge with {yazi_owner} Yazi.",
                     details.join("\n")
                 )),
                 fix_available: false,
@@ -701,6 +740,11 @@ mod tests {
         let path = runtime.join("libexec").join(command);
         std::fs::create_dir_all(path.parent().unwrap()).unwrap();
         std::fs::write(path, "").unwrap();
+    }
+
+    fn write_path_command(path_dir: &Path, command: &str) {
+        std::fs::create_dir_all(path_dir).unwrap();
+        std::fs::write(path_dir.join(command), "").unwrap();
     }
 
     fn shared_with_terminal(terminal: &str) -> SharedRuntimePreflightInput {
@@ -884,7 +928,8 @@ mod tests {
         write_runtime_command(&runtime, "zellij");
         write_runtime_command(&runtime, "yazi");
 
-        let findings = build_runtime_graphics_findings(&shared_with_terminal("ghostty"), &runtime);
+        let findings =
+            build_runtime_graphics_findings(&shared_with_terminal("ghostty"), &runtime, &[]);
 
         assert_eq!(findings[0].status, "ok");
         assert_eq!(
@@ -901,6 +946,98 @@ mod tests {
         );
     }
 
+    // Regression: host-sourced Yazi is a supported Home Manager runtime-tool source and should satisfy the graphics bridge check.
+    #[test]
+    fn graphics_strategy_accepts_host_sourced_yazi() {
+        let tmp = TempDir::new().unwrap();
+        let runtime = tmp.path().join("runtime");
+        let path_dir = tmp.path().join("host_path");
+        std::fs::create_dir_all(runtime.join("runtime_features")).unwrap();
+        std::fs::write(
+            runtime_feature_path(&runtime, ZELLIJ_KITTY_PASSTHROUGH_FEATURE),
+            "",
+        )
+        .unwrap();
+        std::fs::write(
+            runtime.join("runtime_tools.json"),
+            r#"{
+              "yazi": {
+                "source": "host",
+                "commands": ["yazi", "ya"],
+                "required_commands": ["yazi"]
+              }
+            }"#,
+        )
+        .unwrap();
+        write_runtime_command(&runtime, "zellij");
+        write_path_command(&path_dir, "yazi");
+
+        let findings = build_runtime_graphics_findings(
+            &shared_with_terminal("ghostty"),
+            &runtime,
+            &[path_dir],
+        );
+
+        assert_eq!(findings[0].status, "ok");
+        assert_eq!(
+            findings[0].capability_mode.as_deref(),
+            Some("kitty_passthrough_bridge")
+        );
+        assert!(
+            findings[0]
+                .details
+                .as_deref()
+                .unwrap_or_default()
+                .contains("Runtime Yazi command: host PATH")
+        );
+    }
+
+    // Regression: declaring host-sourced Yazi is not enough; the host command must be visible on PATH.
+    #[test]
+    fn graphics_strategy_warns_when_host_sourced_yazi_is_missing() {
+        let tmp = TempDir::new().unwrap();
+        let runtime = tmp.path().join("runtime");
+        let path_dir = tmp.path().join("empty_path");
+        std::fs::create_dir_all(runtime.join("runtime_features")).unwrap();
+        std::fs::create_dir_all(&path_dir).unwrap();
+        std::fs::write(
+            runtime_feature_path(&runtime, ZELLIJ_KITTY_PASSTHROUGH_FEATURE),
+            "",
+        )
+        .unwrap();
+        std::fs::write(
+            runtime.join("runtime_tools.json"),
+            r#"{
+              "yazi": {
+                "source": "host",
+                "commands": ["yazi", "ya"],
+                "required_commands": ["yazi"]
+              }
+            }"#,
+        )
+        .unwrap();
+        write_runtime_command(&runtime, "zellij");
+
+        let findings = build_runtime_graphics_findings(
+            &shared_with_terminal("ghostty"),
+            &runtime,
+            &[path_dir],
+        );
+
+        assert_eq!(findings[0].status, "warning");
+        assert_eq!(
+            findings[0].capability_mode.as_deref(),
+            Some("kitty_passthrough_bridge_incomplete")
+        );
+        assert!(
+            findings[0]
+                .details
+                .as_deref()
+                .unwrap_or_default()
+                .contains("Runtime Yazi command: missing")
+        );
+    }
+
     // Regression: Ghostty/Ratty graphics diagnostics must warn on an incomplete bridge instead of claiming support from terminal identity alone.
     #[test]
     fn graphics_strategy_warns_for_ratty_without_bridge_marker() {
@@ -909,7 +1046,8 @@ mod tests {
         write_runtime_command(&runtime, "zellij");
         write_runtime_command(&runtime, "yazi");
 
-        let findings = build_runtime_graphics_findings(&shared_with_terminal("ratty"), &runtime);
+        let findings =
+            build_runtime_graphics_findings(&shared_with_terminal("ratty"), &runtime, &[]);
 
         assert_eq!(findings[0].status, "warning");
         assert_eq!(
@@ -944,7 +1082,8 @@ mod tests {
         write_runtime_command(&runtime, "zellij");
         write_runtime_command(&runtime, "yazi");
 
-        let findings = build_runtime_graphics_findings(&shared_with_terminal("ghostty"), &runtime);
+        let findings =
+            build_runtime_graphics_findings(&shared_with_terminal("ghostty"), &runtime, &[]);
 
         assert_eq!(findings[0].status, "ok");
         assert_eq!(findings[1].status, "warning");


### PR DESCRIPTION
## Summary

This fixes a `yzx doctor` false warning I found while testing the #587 / #596 doctor/runtime path on my NixOS + Home Manager setup:

```
⚠️  Graphics previews: configured terminal expects the Yazelix Kitty bridge, but the runtime is incomplete
✅ Host runtime tool available: yazi
```

My config intentionally uses host-sourced Yazi:

```nix
programs.yazelix.runtime_tool_sources.yazi = "host";
```

Doctor already recognizes that part correctly and reports the host runtime tool as available. The graphics-preview check, though, still required a runtime-owned `yazi` command under the packaged runtime, so it warned that the Kitty bridge runtime was incomplete even though the configured host `yazi` was available.

## What changed

- Pass the runtime tool command search paths into the graphics diagnostics
- Accept host-sourced Yazi when `runtime_tools.json` says `yazi.source = "host"` and the required host command is visible
- Keep the warning when host-sourced Yazi is configured but the command is missing
- Reuse the existing required-command selection logic instead of duplicating it

## Validation

- `nix develop -c cargo test --manifest-path rust_core/yazelix_core/Cargo.toml doctor_runtime_report`
- `nix develop -c cargo fmt --manifest-path rust_core/yazelix_core/Cargo.toml --check`
- `nix develop -c cargo check --manifest-path rust_core/yazelix_core/Cargo.toml`

## Small follow-up question

While reading this path I also noticed that `command_exists_in_paths` checks `is_file()` but not whether the file is executable. I left that untouched here because it affects every host runtime tool check, not just Yazi.

Would you prefer that I tighten that check in this PR as well, or keep it as a separate follow-up?
