### PR TITLE
chore: add prek to maintainer shell

### DIFF
--- a/maintainer_shell.nix
+++ b/maintainer_shell.nix
@@ -24,6 +24,7 @@ let
   openssl = pkgs.openssl;
   maintainerDeps =
     [ pkgs.github-cli ]
+    ++ [ pkgs.prek ]
     ++ [ pkgs.nu-lint ]
     ++ [ pkgs.cargo-nextest ]
     ++ [ pkgs.cargo-llvm-cov ]


### PR DESCRIPTION
Hi Lucca,

I reckon the `pkgs.prek`  could be placed in the Yazelix maintainer shell.

As our docs said: `prek run --all-files` plays a role as the cheap maintainer hook lane and the repository includes a root `.pre-commit-config.yaml`. So it'll be convinenient if we have it in the env. :heart: 