### PR TITLE
fix: enter startup cwd

### DIFF
--- a/configs/zellij/layouts/yzx_side.kdl
+++ b/configs/zellij/layouts/yzx_side.kdl
@@ -25,6 +25,8 @@ layout {
          }
      }
 
+     tab
+
      new_tab_template cwd="__YAZELIX_HOME_DIR__" {
          pane size=1 borderless=true {
             __YAZELIX_ZJSTATUS_TAB_TEMPLATE__

--- a/configs/zellij/layouts/yzx_side_closed.kdl
+++ b/configs/zellij/layouts/yzx_side_closed.kdl
@@ -25,6 +25,8 @@ layout {
          }
      }
 
+     tab
+
      new_tab_template cwd="__YAZELIX_HOME_DIR__" {
          pane size=1 borderless=true {
             __YAZELIX_ZJSTATUS_TAB_TEMPLATE__

--- a/rust_core/yazelix_core/src/launch_commands.rs
+++ b/rust_core/yazelix_core/src/launch_commands.rs
@@ -1,9 +1,11 @@
 // Test lane: default
 //! Rust-owned `yzx enter`, `yzx launch`, `yzx desktop`, and `yzx restart` owners.
 
-use crate::bridge::CoreError;
-use crate::control_plane::home_dir_from_env;
-use std::path::PathBuf;
+use crate::bridge::{CoreError, ErrorClass};
+use crate::control_plane::{home_dir_from_env, state_dir_from_env};
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
 
 mod config_override;
 mod desktop;
@@ -14,6 +16,8 @@ mod restart;
 mod terminal;
 
 use desktop::*;
+
+const SIDEBAR_BOOTSTRAP_CWD_ENV: &str = "YAZELIX_BOOTSTRAP_SIDEBAR_CWD_FILE";
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 struct DesktopArgs {
@@ -61,6 +65,89 @@ pub fn run_yzx_desktop(args: &[String]) -> Result<i32, CoreError> {
         ))),
         None => unreachable!(),
     }
+}
+
+fn create_sidebar_bootstrap_file(owner: &str, target_dir: &Path) -> Result<PathBuf, CoreError> {
+    create_sidebar_bootstrap_file_in_state(&state_dir_from_env()?, owner, target_dir)
+}
+
+fn create_sidebar_bootstrap_file_in_state(
+    state_dir: &Path,
+    owner: &str,
+    target_dir: &Path,
+) -> Result<PathBuf, CoreError> {
+    let bootstrap_dir = state_dir.join("sidebar_bootstrap").join(owner);
+    fs::create_dir_all(&bootstrap_dir).map_err(|source| {
+        CoreError::io(
+            "sidebar_bootstrap_state_dir",
+            format!(
+                "Could not create sidebar bootstrap state directory {}.",
+                bootstrap_dir.display()
+            ),
+            "Fix the directory permissions, then retry.",
+            bootstrap_dir.display().to_string(),
+            source,
+        )
+    })?;
+    let timestamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_err(|error| {
+            CoreError::classified(
+                ErrorClass::Internal,
+                "system_clock_error",
+                format!("System clock error while preparing sidebar bootstrap file: {error}"),
+                "Fix the system clock, then retry.",
+                serde_json::json!({}),
+            )
+        })?
+        .as_millis();
+    let path = bootstrap_dir.join(format!("cwd_{}_{}.tmp", std::process::id(), timestamp));
+    fs::write(&path, target_dir.to_string_lossy().into_owned()).map_err(|source| {
+        CoreError::io(
+            "sidebar_bootstrap_write",
+            format!("Could not write sidebar bootstrap file {}.", path.display()),
+            "Fix the directory permissions, then retry.",
+            path.display().to_string(),
+            source,
+        )
+    })?;
+    Ok(path)
+}
+
+fn sidebar_bootstrap_extra_env(
+    owner: &str,
+    target_dir: &Path,
+) -> Result<Vec<(String, Option<String>)>, CoreError> {
+    let inherited = std::env::var(SIDEBAR_BOOTSTRAP_CWD_ENV).ok();
+    sidebar_bootstrap_extra_env_for_state(
+        &state_dir_from_env()?,
+        owner,
+        target_dir,
+        inherited.as_deref(),
+    )
+}
+
+fn sidebar_bootstrap_extra_env_for_state(
+    state_dir: &Path,
+    owner: &str,
+    target_dir: &Path,
+    inherited: Option<&str>,
+) -> Result<Vec<(String, Option<String>)>, CoreError> {
+    if inherited_sidebar_bootstrap_file(inherited).is_some() {
+        return Ok(Vec::new());
+    }
+
+    let path = create_sidebar_bootstrap_file_in_state(state_dir, owner, target_dir)?;
+    Ok(vec![(
+        SIDEBAR_BOOTSTRAP_CWD_ENV.to_string(),
+        Some(path.to_string_lossy().into_owned()),
+    )])
+}
+
+fn inherited_sidebar_bootstrap_file(raw: Option<&str>) -> Option<PathBuf> {
+    let raw = raw.map(str::trim).filter(|value| !value.is_empty())?;
+    let path = PathBuf::from(raw);
+    path.is_file().then_some(path)
 }
 
 fn parse_desktop_args(args: &[String]) -> Result<DesktopArgs, CoreError> {
@@ -198,6 +285,45 @@ mod tests {
                 Some("/tmp/custom.jsonc".to_string())
             )]
         );
+    }
+
+    // Regression: startup sidebar yazi gets the requested session cwd through an explicit bootstrap file instead of inheriting Zellij's home-scoped pane cwd.
+    #[test]
+    fn sidebar_bootstrap_env_writes_requested_startup_cwd() {
+        let state = TempDir::new().expect("state dir");
+        let target = state.path().join("project");
+        fs::create_dir_all(&target).expect("target dir");
+
+        let env =
+            sidebar_bootstrap_extra_env_for_state(state.path(), "enter", &target, None).unwrap();
+
+        assert_eq!(env.len(), 1);
+        assert_eq!(env[0].0, SIDEBAR_BOOTSTRAP_CWD_ENV);
+        let bootstrap_file = PathBuf::from(env[0].1.as_ref().unwrap());
+        assert!(bootstrap_file.starts_with(state.path().join("sidebar_bootstrap").join("enter")));
+        assert_eq!(
+            fs::read_to_string(bootstrap_file).unwrap(),
+            target.to_string_lossy()
+        );
+    }
+
+    // Defends: restart can pass its existing one-shot sidebar cwd through launch/enter without enter replacing it with a terminal-emulator fallback cwd.
+    #[test]
+    fn sidebar_bootstrap_env_preserves_existing_restart_file() {
+        let state = TempDir::new().expect("state dir");
+        let inherited = state.path().join("restart_cwd.tmp");
+        fs::write(&inherited, "/restart/cwd").expect("restart bootstrap");
+
+        let env = sidebar_bootstrap_extra_env_for_state(
+            state.path(),
+            "enter",
+            Path::new("/terminal/cwd"),
+            Some(&inherited.to_string_lossy()),
+        )
+        .unwrap();
+
+        assert!(env.is_empty());
+        assert_eq!(fs::read_to_string(inherited).unwrap(), "/restart/cwd");
     }
 
     // Defends: restart exposes a one-shot welcome skip flag without making the config skip setting sticky.

--- a/rust_core/yazelix_core/src/launch_commands/enter.rs
+++ b/rust_core/yazelix_core/src/launch_commands/enter.rs
@@ -3,6 +3,7 @@ use super::config_override::{
 };
 use super::process::{command_status_with_overrides, find_command};
 use super::resolve_requested_working_dir;
+use super::sidebar_bootstrap_extra_env;
 use crate::bridge::{CoreError, ErrorClass};
 use crate::command_metadata::{YzxExternBridgeSyncRequest, sync_yzx_extern_bridge};
 use crate::control_plane::{
@@ -46,7 +47,7 @@ pub(super) fn run_enter(args: &[String]) -> Result<i32, CoreError> {
             .or(inherited_config_override.as_deref()),
         &parsed.with_overrides,
     )?;
-    let config_extra_env = config_override_extra_env(config_override.as_deref());
+    let mut extra_env = config_override_extra_env(config_override.as_deref());
     let normalized =
         load_normalized_config_for_control(&runtime_dir, &config_dir, config_override.as_deref())?;
     let req = runtime_env_request(runtime_dir.clone(), &normalized)?;
@@ -96,6 +97,7 @@ pub(super) fn run_enter(args: &[String]) -> Result<i32, CoreError> {
     })?;
 
     run_runtime_setup(&runtime_dir, &default_shell, true)?;
+    extra_env.extend(sidebar_bootstrap_extra_env("enter", &working_dir)?);
 
     let mut argv = vec![
         nu_bin.to_string_lossy().into_owned(),
@@ -111,7 +113,7 @@ pub(super) fn run_enter(args: &[String]) -> Result<i32, CoreError> {
         Some(&runtime_env),
         &working_dir,
         &[],
-        &config_extra_env,
+        &extra_env,
         "enter_startup",
         "Retry from a valid Yazelix runtime or relaunch with `yzx launch`.",
     )?;

--- a/rust_core/yazelix_core/src/launch_commands/restart.rs
+++ b/rust_core/yazelix_core/src/launch_commands/restart.rs
@@ -2,15 +2,15 @@ use super::config_override::{
     config_override_extra_env, prepare_session_config_override, resolve_cli_config_override,
 };
 use super::process::{command_output_with_overrides, print_completed_output};
-use crate::bridge::{CoreError, ErrorClass};
-use crate::control_plane::{config_override_from_env, home_dir_from_env, runtime_dir_from_env};
+use super::{SIDEBAR_BOOTSTRAP_CWD_ENV, create_sidebar_bootstrap_file};
+use crate::bridge::CoreError;
+use crate::control_plane::{config_override_from_env, runtime_dir_from_env};
 use crate::install_ownership_env::install_ownership_request_from_env_with_runtime_dir;
 use crate::install_ownership_report::evaluate_install_ownership_report;
-use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::process::Command;
 use std::thread;
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::time::Duration;
 
 pub(super) const RESTART_LAUNCH_CLEARED_ENV_KEYS: &[&str] = &[
     "IN_YAZELIX_SHELL",
@@ -56,8 +56,9 @@ pub(super) fn run_restart(args: &[String]) -> Result<i32, CoreError> {
     }
 
     let session_to_kill = current_zellij_session();
-    let restart_file =
-        create_restart_sidebar_bootstrap_file(&std::env::current_dir().map_err(|source| {
+    let restart_file = create_sidebar_bootstrap_file(
+        "restart",
+        &std::env::current_dir().map_err(|source| {
             CoreError::io(
                 "restart_cwd",
                 "Could not read the current working directory.",
@@ -65,7 +66,8 @@ pub(super) fn run_restart(args: &[String]) -> Result<i32, CoreError> {
                 ".",
                 source,
             )
-        })?)?;
+        })?,
+    )?;
 
     let is_yzxterm = std::env::var_os("YAZELIX_TERMINAL").is_some();
     if is_yzxterm {
@@ -91,7 +93,7 @@ pub(super) fn run_restart(args: &[String]) -> Result<i32, CoreError> {
         .map(PathBuf::from)
         .unwrap_or_else(|| runtime_dir.join("shells").join("posix").join("yzx_cli.sh"));
     let mut restart_extra_env = vec![(
-        "YAZELIX_BOOTSTRAP_SIDEBAR_CWD_FILE".to_string(),
+        SIDEBAR_BOOTSTRAP_CWD_ENV.to_string(),
         Some(restart_file.to_string_lossy().into_owned()),
     )];
     if parsed.skip_welcome {
@@ -239,50 +241,6 @@ fn strip_ansi(text: &str) -> String {
         out.push(ch);
     }
     out
-}
-
-fn create_restart_sidebar_bootstrap_file(target_dir: &Path) -> Result<PathBuf, CoreError> {
-    let state_dir = home_dir_from_env()?
-        .join(".local")
-        .join("share")
-        .join("yazelix")
-        .join("state")
-        .join("restart");
-    fs::create_dir_all(&state_dir).map_err(|source| {
-        CoreError::io(
-            "restart_state_dir",
-            format!(
-                "Could not create restart state directory {}.",
-                state_dir.display()
-            ),
-            "Fix the directory permissions, then retry.",
-            state_dir.display().to_string(),
-            source,
-        )
-    })?;
-    let timestamp = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map_err(|error| {
-            CoreError::classified(
-                ErrorClass::Internal,
-                "system_clock_error",
-                format!("System clock error while preparing restart bootstrap file: {error}"),
-                "Fix the system clock, then retry.",
-                serde_json::json!({}),
-            )
-        })?
-        .as_millis();
-    let path = state_dir.join(format!("sidebar_cwd_{timestamp}.tmp"));
-    fs::write(&path, target_dir.to_string_lossy().into_owned()).map_err(|source| {
-        CoreError::io(
-            "restart_sidebar_bootstrap",
-            format!("Could not write restart bootstrap file {}.", path.display()),
-            "Fix the directory permissions, then retry.",
-            path.display().to_string(),
-            source,
-        )
-    })?;
-    Ok(path)
 }
 
 fn kill_zellij_session(session_name: Option<&str>) {

--- a/rust_core/yazelix_core/src/launch_materialization.rs
+++ b/rust_core/yazelix_core/src/launch_materialization.rs
@@ -3,18 +3,18 @@
 
 use crate::active_config_surface::resolve_active_config_paths;
 use crate::bridge::CoreError;
-use crate::config_normalize::{normalize_config, NormalizeConfigRequest};
+use crate::config_normalize::{NormalizeConfigRequest, normalize_config};
 use crate::control_plane::{config_dir_from_env, runtime_dir_from_env, state_dir_from_env};
 use crate::ghostty_cursor_registry::{
     CursorRegistry, ResolvedCursorRegistryState, YazelixCursorRegistryExt,
 };
 use crate::ghostty_materialization::{
-    generate_ghostty_materialization, GhosttyMaterializationRequest,
+    GhosttyMaterializationRequest, generate_ghostty_materialization,
 };
 use crate::runtime_component_enabled;
 use crate::terminal_materialization::{
-    generate_terminal_materialization, yzxterm_profile_from_env, TerminalGeneratedConfig,
-    TerminalMaterializationRequest, YzxtermProfile,
+    TerminalGeneratedConfig, TerminalMaterializationRequest, YzxtermProfile,
+    generate_terminal_materialization, yzxterm_profile_from_env,
 };
 use crate::terminal_variant::active_terminal_from_runtime_dir;
 use serde::Serialize;

--- a/rust_core/yazelix_core/src/zellij_materialization.rs
+++ b/rust_core/yazelix_core/src/zellij_materialization.rs
@@ -3088,6 +3088,81 @@ printf '%s\n' '{"schema_version":2,"plugin_block":"CHILD_PLUGIN_BLOCK"}'
         assert!(!rendered.contains(r#"args "sidebar" "yazi""#));
     }
 
+    // Regression: startup layouts declare the initial tab explicitly so launch cwd stays owned by
+    // Zellij --default-cwd while new tabs remain home-scoped.
+    #[test]
+    fn startup_layouts_keep_initial_tab_distinct_from_home_scoped_new_tabs() {
+        for (name, content) in [
+            (
+                "yzx_side.kdl",
+                include_str!("../../../configs/zellij/layouts/yzx_side.kdl"),
+            ),
+            (
+                "yzx_side_closed.kdl",
+                include_str!("../../../configs/zellij/layouts/yzx_side_closed.kdl"),
+            ),
+        ] {
+            let mut default_template_line = None;
+            let mut initial_tab_line = None;
+            let mut new_tab_line = None;
+            let mut layout_depth = 0usize;
+
+            for (line_number, line) in content.lines().enumerate() {
+                let trimmed = line.trim();
+
+                if layout_depth == 1 {
+                    match trimmed {
+                        "default_tab_template {" => {
+                            assert!(
+                                default_template_line.replace(line_number).is_none(),
+                                "{name} declares default_tab_template more than once"
+                            );
+                        }
+                        "tab" => {
+                            assert!(
+                                initial_tab_line.replace(line_number).is_none(),
+                                "{name} declares more than one explicit initial tab"
+                            );
+                        }
+                        r#"new_tab_template cwd="__YAZELIX_HOME_DIR__" {"# => {
+                            assert!(
+                                new_tab_line.replace(line_number).is_none(),
+                                "{name} declares home-scoped new_tab_template more than once"
+                            );
+                        }
+                        _ => {}
+                    }
+                }
+
+                let closing_braces = trimmed.matches('}').count();
+                assert!(
+                    closing_braces <= layout_depth,
+                    "{name} closes more layout blocks than it opens before line {}",
+                    line_number + 1
+                );
+                layout_depth -= closing_braces;
+                layout_depth += trimmed.matches('{').count();
+            }
+            assert_eq!(layout_depth, 0, "{name} leaves layout blocks unclosed");
+
+            let default_template_line = default_template_line
+                .unwrap_or_else(|| panic!("{name} missing default_tab_template"));
+            let initial_tab_line =
+                initial_tab_line.unwrap_or_else(|| panic!("{name} missing explicit initial tab"));
+            let new_tab_line = new_tab_line
+                .unwrap_or_else(|| panic!("{name} missing home-scoped new_tab_template"));
+
+            assert!(
+                default_template_line < initial_tab_line,
+                "{name} initial tab must follow default_tab_template"
+            );
+            assert!(
+                initial_tab_line < new_tab_line,
+                "{name} initial tab must precede home-scoped new_tab_template"
+            );
+        }
+    }
+
     // Defends: generated layouts insert the child-owned zjstatus plugin block without inspecting its internals.
     #[test]
     fn substitutes_child_zjstatus_plugin_block() {


### PR DESCRIPTION
Hi Lucca,

I ran into this while using `yzx enter` from a project directory: Yazelix started, but the first Yazi/sidebar view landed in my home directory instead of the directory I launched from.

After digging through the Zellij layout behavior, I think there were two separate pieces interacting here.

The side layouts already had a `default_tab_template`, and they also had a `new_tab_template cwd="__YAZELIX_HOME_DIR__"`. That home-scoped `new_tab_template` still makes sense to me: when you create a fresh tab later, it should keep using home as you intended (**isn't it?**).

The surprising bit was startup. Without an explicit initial `tab`, Zellij can end up applying the home-scoped new-tab template to the first tab as well. So this PR adds a bare startup `tab` between `default_tab_template` and `new_tab_template`. That keeps the startup tab tied to Zellij's `--default-cwd`, while preserving your home-scoped behavior for newly-created tabs.

There was one more wrinkle: the managed sidebar Yazi pane is launched from the layout pane context, so it can still inherit the home-scoped pane cwd even after the startup tab itself is correct. I reused the existing one-shot sidebar cwd bootstrap idea from `yzx restart` and made `yzx enter` use the same kind of handoff. That way the sidebar opens at the requested startup cwd too.

So the intended behavior after this PR is:

- `yzx enter` from a project starts the first Yazelix tab in that project
- the managed sidebar Yazi also opens in that project
- new tabs still use the existing home-scoped `new_tab_template`

I also included a small rustfmt-only import cleanup in `launch_materialization.rs`. This matches the repo's Nix/Fenix `rustfmt 1.9.0-stable` toolchain used by the CI shell.

## Testing

Manual packaged smoke test from the checked-out PR branch, with an isolated temporary `HOME` so stale local user config does not affect the result:

```bash
repo="$(git rev-parse --show-toplevel)"
runtime="$(nix build "$repo#runtime_wezterm" --no-link --print-out-paths)"
tmp="$(mktemp -d)"
mkdir -p "$tmp/home" "$tmp/project"
cd "$tmp/project"
HOME="$tmp/home" YAZELIX_SKIP_STABLE_WRAPPER_REDIRECT=1 "$runtime/bin/yzx" enter --verbose
```

Expected result:

- The initial Yazelix/Zellij session starts in `$tmp/project`
- The managed sidebar Yazi opens in `$tmp/project`
- Creating a new tab still uses the home-scoped new-tab behavior, with home isolated to `$tmp/home` for this smoke test