### PR TITLE
[codex] Fix indented string warning in Home Manager module

### DIFF
--- a/home_manager/module.nix
+++ b/home_manager/module.nix
@@ -21,7 +21,7 @@ let
   defaultTerminal = terminalMetadata.default;
   terminalVariants = terminalMetadata.supported;
   terminalDescriptionBullets = lib.concatMapStringsSep "\n" (
-    terminal: ''        - "${terminal}": ${terminalMetadata.description terminal}''
+    terminal: "        - \"${terminal}\": ${terminalMetadata.description terminal}"
   ) terminalVariants;
   runtimeToolSourceModes = [
     "bundled"


### PR DESCRIPTION
## Summary

Fix a Nix/Lix parser warning in the Home Manager module by replacing a single-line indented string with an equivalent normal quoted string.

## Root cause

`terminalDescriptionBullets` used a one-line `''` string whose content begins with spaces. Newer Nix/Lix warns that leading whitespace in this form will be stripped, which makes the option documentation text noisy during evaluation.

## Validation

- Confirmed the fork checkout was based on latest upstream `main` at `c020cac1ba6ae53d49d3b0a06414866317e5eef4`.
- Scanned all 30 `.nix` files before the fix: one parser-confirmed `broken-string-indentation` warning at `home_manager/module.nix:24`.
- Scanned all 30 `.nix` files after the fix: zero parser-confirmed `broken-string-indentation` warnings and zero parse failures.
- Ran `nix-instantiate --parse home_manager/module.nix`: exit 0 with empty stderr.