### PR TITLE
Allow substituting the Yazelix wrapper package

### DIFF
--- a/packaging/mk_yazelix_package.nix
+++ b/packaging/mk_yazelix_package.nix
@@ -49,6 +49,8 @@ let
 in
 pkgs.symlinkJoin {
   inherit name;
+  allowSubstitutes = true;
+  preferLocalBuild = false;
   paths = [ runtime ];
 
   nativeBuildInputs = [ pkgs.makeWrapper ];

--- a/rust_core/yazelix_maintainer/src/repo_contract_validation/nix_interface.rs
+++ b/rust_core/yazelix_maintainer/src/repo_contract_validation/nix_interface.rs
@@ -79,6 +79,30 @@ pub fn validate_nix_customization_api(repo_root: &Path) -> Result<ValidationRepo
         "overlays.default must expose a yazelix package with yzx as the main program",
         &mut report.errors,
     );
+    require_json_bool(
+        object,
+        "default_package_allows_substitutes",
+        "default flake package must allow substitutes so published Cachix paths can be used",
+        &mut report.errors,
+    );
+    require_json_bool(
+        object,
+        "default_package_does_not_prefer_local_build",
+        "default flake package must not prefer local builds over published substitutes",
+        &mut report.errors,
+    );
+    require_json_bool(
+        object,
+        "mk_default_package_allows_substitutes",
+        "lib.<system>.mkYazelix default package must allow substitutes so published Cachix paths can be used",
+        &mut report.errors,
+    );
+    require_json_bool(
+        object,
+        "mk_default_package_does_not_prefer_local_build",
+        "lib.<system>.mkYazelix default package must not prefer local builds over published substitutes",
+        &mut report.errors,
+    );
     require_json_string(
         object,
         "home_manager_runtime_tool_source",
@@ -534,6 +558,10 @@ fn build_nix_customization_api_expr(repo_root: &Path) -> String {
         "  default_main_program = defaultPackage.meta.mainProgram or \"\";".to_string(),
         "  mk_default_main_program = mkDefaultPackage.meta.mainProgram or \"\";".to_string(),
         "  overlay_main_program = overlayPkgs.yazelix.meta.mainProgram or \"\";".to_string(),
+        "  default_package_allows_substitutes = (defaultPackage.allowSubstitutes or true) == true;".to_string(),
+        "  default_package_does_not_prefer_local_build = (defaultPackage.preferLocalBuild or false) == false;".to_string(),
+        "  mk_default_package_allows_substitutes = (mkDefaultPackage.allowSubstitutes or true) == true;".to_string(),
+        "  mk_default_package_does_not_prefer_local_build = (mkDefaultPackage.preferLocalBuild or false) == false;".to_string(),
         "  home_manager_runtime_tool_source = hm.config.programs.yazelix.runtime_tool_sources.helix or \"\";".to_string(),
         "  home_manager_steel_tool_source = hm.config.programs.yazelix.runtime_tool_sources.steel or \"\";".to_string(),
         "  steel_bundled_exports_authoring_commands = builtins.all (command: builtins.elem command steelBundledRegistry.exportedCommands) steelAuthoringCommands;".to_string(),


### PR DESCRIPTION
Hi Lucca,

I noticed one small cache-policy mismatch around the main `#yazelix` package.

Yazelix already publishes the default package to Cachix, and the docs describe that cache as helping package installs and Home Manager switches. The expensive runtime paths can substitute correctly, but the outer `symlinkJoin` wrapper still inherited nixpkgs' default policy:

- `preferLocalBuild = true`
- `allowSubstitutes = false`

That means Nix can still schedule the thin `...-yazelix.drv` wrapper for a local build even when a matching published substitute exists.

This PR makes the outer wrapper follow the same cache intent as the rest of the published `#yazelix` package:

- set `allowSubstitutes = true`
- set `preferLocalBuild = false`
- add `validate-nix-customization-api` coverage for both `#yazelix` and `lib.${system}.mkYazelix {}`

This does not claim a cache hit before CI publishes a given commit, and users still need the Yazelix Cachix substituter configured. It only removes the package-level preference for local wrapper builds once a matching substitute exists.

Testing:

```bash
nix develop .#ci -c cargo fmt --all --manifest-path rust_core/Cargo.toml --check
nix develop .#ci -c cargo build --quiet --manifest-path rust_core/Cargo.toml -p yazelix_maintainer --bin yzx_repo_validator
nix develop .#ci -c ./rust_core/target/debug/yzx_repo_validator validate-nix-customization-api
nix eval --json .#yazelix.allowSubstitutes --no-write-lock-file
nix eval --json .#yazelix.preferLocalBuild --no-write-lock-file
nix build .#yazelix --no-link --no-write-lock-file
```

The two eval checks return `true` and `false`, respectively.
